### PR TITLE
チャット画面自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,9 @@
 $(function(){
+  
   function buildHTML(message){
     if ( message.image ){
       var html = 
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
            <div class="upper-message">
              <div class="upper-message__user-name">
                ${message.user_name}
@@ -21,7 +22,7 @@ $(function(){
       return html;
     } else {
       var html = 
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
            <div class="upper-message">
              <div class="upper-message__user-name">
                ${message.user_name}
@@ -40,8 +41,7 @@ $(function(){
     };
   }
 
-
-$("#new_message").on("submit", function(e){
+  $("#new_message").on("submit", function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action")
@@ -63,5 +63,30 @@ $("#new_message").on("submit", function(e){
     .fail(function(){
       alert("メッセージ送信に失敗しました");
     })
-})
+  })
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: "GET",
+      dataType: "json",
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = "";
+        $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+        });
+        $(".messages").append(insertHTML);
+        $(".messages").animate({ scrollTop: $(".messages")[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert("error");
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
-json.image @message.image_url
+json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: "json" }
+    end
   end
 end


### PR DESCRIPTION
# What
自動更新できるようにした。
カスタムデータ属性の追加
reloadMessages関数で一定時間が経過するごとに処理を実行する
自動更新時に、画面が最下部までスクロールする

# Why
毎回リロードしなくても相手からのメッセージが表示されるようになり
快適にチャットができるようにするため

https://i.gyazo.com/07e96a692bf6dfc99531c6e153fca2eb.mp4