### PR TITLE
グループ編集の修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to group_messages_path(current_user), notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end
@@ -33,5 +33,6 @@ class GroupsController < ApplicationController
   def group_params
     params.require(:group).permit(:name, user_ids: [])
   end
+
 
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,7 +10,7 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -10,7 +10,7 @@
         %li.main-header__left-box__member-list__member
           - @group.group_users.each do |group_user|
             = group_user.user.name
-    = link_to edit_group_path(current_user), class:"main-header__edit-btn" do
+    = link_to edit_group_path(@group), class:"main-header__edit-btn" do
       Edit
   .messages
     = render @messages


### PR DESCRIPTION
# What
・編集したいグループのeditボタンを押したチキに、そのグループの編集画面に遷移できるようにした。
# Why
・グループ編集した後にフロント画面に戻ると、毎回グループ1の画面になっていたので修正